### PR TITLE
Wrap CSV fields in quotes

### DIFF
--- a/scrape-saveinfowars.py
+++ b/scrape-saveinfowars.py
@@ -27,5 +27,5 @@ for index, row in df_recent.iterrows():
         df_compiled.sort_index(inplace=True)
 
 # write to data file
-df_compiled.to_csv(csv_filename, sep=',', index=False)
+df_compiled.to_csv(csv_filename, quotechar="", sep=',', index=False)
 


### PR DESCRIPTION
Wrap CSV fields in quotes to prevent comment line breaks from breaking the CSV output you have.